### PR TITLE
Fix punctuation in RollResult.model.bxb.

### DIFF
--- a/models/concepts/RollResult.model.bxb
+++ b/models/concepts/RollResult.model.bxb
@@ -1,5 +1,5 @@
 structure (RollResult) {
-  description (The result object produced by the RollDice action)
+  description (The result object produced by the RollDice action.)
   property (sum) {
     type (Sum)
     min (Required)


### PR DESCRIPTION
We were missing a period in the description. :)